### PR TITLE
Release/v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+phpcs_report.txt

--- a/Block/Cart/ShippingPromotion.php
+++ b/Block/Cart/ShippingPromotion.php
@@ -78,11 +78,11 @@ class ShippingPromotion extends Template
     /**
      * Convert minimum order amount using current store currency
      *
-     * @return string | null
+     * @return string | float
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getFreeShippingMinimumOrderAmountInStoreCurrency(): ?string
+    public function getFreeShippingMinimumOrderAmountInStoreCurrency(): string|float
     {
         $minAmount = $this->getFreeShippingMinimumOrderAmount();
         $currentCurrency = $this->_storeManager->getStore()->getCurrentCurrency()->getCode();

--- a/Block/Cart/ShippingPromotion.php
+++ b/Block/Cart/ShippingPromotion.php
@@ -5,6 +5,9 @@ namespace BeckyDoggett\FreeShippingPromotion\Block\Cart;
 
 use Magento\Framework\View\Element\Template;
 use BeckyDoggett\FreeShippingPromotion\Model\Config\Config as ConfigProvider;
+use Magento\Directory\Model\CurrencyFactory;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Locale\Format as LocaleFormat;
 
 class ShippingPromotion extends Template
 {
@@ -15,18 +18,40 @@ class ShippingPromotion extends Template
     protected ConfigProvider $configProvider;
 
     /**
-     * Construct
-     *
+     * @var \Magento\Directory\Model\CurrencyFactory
+     */
+    protected CurrencyFactory $currencyFactory;
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    protected Json $json;
+
+    /**
+     * @var \Magento\Framework\Locale\Format
+     */
+    protected LocaleFormat $localeFormat;
+
+    /**
      * @param ConfigProvider $configProvider
+     * @param CurrencyFactory $currencyFactory
+     * @param Json $json
+     * @param LocaleFormat $localeFormat
      * @param Template\Context $context
      * @param array $data
      */
     public function __construct(
         ConfigProvider $configProvider,
+        CurrencyFactory $currencyFactory,
+        Json $json,
+        LocaleFormat $localeFormat,
         Template\Context $context,
         array $data = []
     ) {
         $this->configProvider = $configProvider;
+        $this->currencyFactory = $currencyFactory;
+        $this->json = $json;
+        $this->localeFormat = $localeFormat;
         parent::__construct($context, $data);
     }
 
@@ -48,5 +73,36 @@ class ShippingPromotion extends Template
     public function getFreeShippingMinimumOrderAmount(): ?string
     {
         return $this->configProvider->getFreeShippingMinimumOrderAmount();
+    }
+
+    /**
+     * Convert minimum order amount using current store currency
+     *
+     * @return string | null
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getFreeShippingMinimumOrderAmountInStoreCurrency(): ?string
+    {
+        $minAmount = $this->getFreeShippingMinimumOrderAmount();
+        $currentCurrency = $this->_storeManager->getStore()->getCurrentCurrency()->getCode();
+        $baseCurrency = $this->_storeManager->getStore()->getBaseCurrency()->getCode();
+
+        if ($currentCurrency != $baseCurrency) {
+            $rate = $this->currencyFactory->create()->load($baseCurrency)->getAnyRate($currentCurrency);
+            $minAmount = $minAmount * $rate;
+        }
+
+        return $minAmount;
+    }
+
+    /**
+     * Format Price
+     *
+     * @return bool|string
+     */
+    public function getLocalePriceFormatJson(): bool|string
+    {
+        return $this->json->serialize($this->localeFormat->getPriceFormat());
     }
 }

--- a/Block/Cart/ShippingPromotion.php
+++ b/Block/Cart/ShippingPromotion.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace BeckyDoggett\FreeShippingPromotion\Block\Cart;
+
+use Magento\Framework\View\Element\Template;
+use BeckyDoggett\FreeShippingPromotion\Model\Config\Config as ConfigProvider;
+
+class ShippingPromotion extends Template
+{
+
+    /**
+     * @var ConfigProvider
+     */
+    protected ConfigProvider $configProvider;
+
+    /**
+     * Construct
+     *
+     * @param ConfigProvider $configProvider
+     * @param Template\Context $context
+     * @param array $data
+     */
+    public function __construct(
+        ConfigProvider $configProvider,
+        Template\Context $context,
+        array $data = []
+    ) {
+        $this->configProvider = $configProvider;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Check if free shipping is active
+     *
+     * @return bool
+     */
+    public function isFreeShippingActive(): bool
+    {
+        return filter_var($this->configProvider->isFreeShippingActive(), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Get free shipping minimum order amount
+     *
+     * @return string|null
+     */
+    public function getFreeShippingMinimumOrderAmount(): ?string
+    {
+        return $this->configProvider->getFreeShippingMinimumOrderAmount();
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.0.0] - 2025-02-08
+### Added
+- Promotional block for default Free Shipping method
+- When enabled display how much a customer has left to spend before they qualify for free shipping
+- Check if amount includes tax, promotional output is updated depending on setting
+- Ability to enable promotion in the cart
+- Ability to enable promotion in the mini-cart

--- a/CustomerData/CartTotals.php
+++ b/CustomerData/CartTotals.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace BeckyDoggett\FreeShippingPromotion\CustomerData;
+
+use Magento\Checkout\Model\Session;
+use Magento\Customer\CustomerData\SectionSourceInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Pricing\Helper\Data as PricingHelper;
+use Magento\Quote\Api\CartTotalRepositoryInterface;
+use Psr\Log\LoggerInterface;
+
+class CartTotals implements SectionSourceInterface
+{
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected Session $checkoutSession;
+
+    /**
+     * @var \Magento\Framework\Pricing\Helper\Data
+     */
+    protected PricingHelper $pricingHelper;
+
+    /**
+     * @var \Magento\Quote\Api\CartTotalRepositoryInterface
+     */
+    protected CartTotalRepositoryInterface $cartTotalRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Construct
+     *
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Framework\Pricing\Helper\Data $pricingHelper
+     * @param \Magento\Quote\Api\CartTotalRepositoryInterface $cartTotalRepository
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        Session $checkoutSession,
+        PricingHelper $pricingHelper,
+        CartTotalRepositoryInterface $cartTotalRepository,
+        LoggerInterface $logger
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->pricingHelper = $pricingHelper;
+        $this->cartTotalRepository = $cartTotalRepository;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Add subtotal excl and incl data to customerData
+     *
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getSectionData(): array
+    {
+        $quote = $this->checkoutSession->getQuote();
+
+        if (!$quote || !$quote->getId()) {
+            return [];
+        }
+
+        $additionalSectionData = [];
+
+        try {
+            $totals = $this->cartTotalRepository->get($quote->getId());
+            //$this->logger->debug('Totals', $totals);
+
+            if (isset($totals['subtotal'])) {
+                $additionalSectionData = [
+                    'subtotalExcTax' => $totals->getSubtotalExclTax() ?: $totals->getSubtotal(),
+                    'subtotalIncTax' => $totals->getSubtotalInclTax(),
+                ];
+            }
+        } catch (NoSuchEntityException $e) {
+            $this->logger->error($e);
+        }
+
+        return $additionalSectionData;
+    }
+}

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace BeckyDoggett\FreeShippingPromotion\Model\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface as StoreScopeInterface;
+use Magento\Store\Model\Store;
+
+class Config
+{
+
+    private const FREE_SHIPPING_ACTIVE = 'carriers/freeshipping/active';
+
+    private const FREE_SHIPPING_AMOUNT = 'carriers/freeshipping/free_shipping_subtotal';
+
+    /**
+     * @todo check tax setting
+     * tax_including
+     */
+
+    /**
+     * @todo check applicable countries
+     * sallowspecific
+     * specificcountry
+     */
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private ScopeConfigInterface $scopeConfig;
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+    ) {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Check if free shipping is active
+     *
+     * @param \Magento\Store\Model\Store|null $store
+     * @return string|null
+     */
+    public function isFreeShippingActive(Store $store = null): ?string
+    {
+        return $this->scopeConfig->getValue(
+            self::FREE_SHIPPING_ACTIVE,
+            StoreScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get free shipping minimum order amount
+     *
+     * @param \Magento\Store\Model\Store|null $store
+     * @return string|null
+     */
+    public function getFreeShippingMinimumOrderAmount(Store $store = null): ?string
+    {
+        return $this->scopeConfig->getValue(
+            self::FREE_SHIPPING_AMOUNT,
+            StoreScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+}

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -14,10 +14,7 @@ class Config
 
     private const FREE_SHIPPING_AMOUNT = 'carriers/freeshipping/free_shipping_subtotal';
 
-    /**
-     * @todo check tax setting
-     * tax_including
-     */
+    private const FREE_SHIPPING_AMOUNT_TAX_INCLUDED = 'carriers/freeshipping/tax_including';
 
     /**
      * @todo check applicable countries
@@ -64,6 +61,21 @@ class Config
     {
         return $this->scopeConfig->getValue(
             self::FREE_SHIPPING_AMOUNT,
+            StoreScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Check if tax is included in amount
+     *
+     * @param \Magento\Store\Model\Store|null $store
+     * @return string|null
+     */
+    public function isAmountIncludingTax(Store $store = null): ?string
+    {
+        return $this->scopeConfig->getValue(
+            self::FREE_SHIPPING_AMOUNT_TAX_INCLUDED,
             StoreScopeInterface::SCOPE_STORE,
             $store
         );

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Module checks to see if the default Magento Free Shipping carrier is enabled:
 The minimum order amount is checked and details of how much a customer needs to spend
 to qualify is output in the cart.
 
+If they are over the minimum order amount for free delivery they are notified
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Free Shipping Promotion Magento Module
+
+## Description
 Promote amount left to spend to qualify for free shipping
 
+## Details
+Module checks to see if the default Magento Free Shipping carrier is enabled:
+`System > Sales > Delivery Method > Free Shipping`
+
+The minimum order amount is checked and details of how much a customer needs to spend
+to qualify is output in the cart.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# magento2-module-free-shipping-promotion
+# Free Shipping Promotion Magento Module
 Promote amount left to spend to qualify for free shipping
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Free Shipping Promotion Magento Module
+# Free Shipping Promotion Magento Module [v1.0.0]
 
 ## Description
 Promote amount left to spend to qualify for free shipping

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ to qualify is output in the cart.
 
 If they are over the minimum order amount for free delivery they are notified
 
+## Configuration
+Ability to enable promotion in the cart:
+`System > Sales > Delivery Method > Free Shipping > Promote Free Shipping in Cart`
+
+Ability to enable promotion in the mini cart:
+`System > Sales > Delivery Method > Free Shipping > Promote Free Shipping in Mini Cart`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Module checks to see if the default Magento Free Shipping carrier is enabled:
 The minimum order amount is checked and details of how much a customer needs to spend
 to qualify is output in the cart.
 
-If they are over the minimum order amount for free delivery they are notified
+If they are over the minimum order amount for free delivery they are notified that they 
+qualify for free shipping.
 
 ## Configuration
 Ability to enable promotion in the cart:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "beckydoggett/magento2-module-free-shipping-promotion",
+    "description": "Promote amount left to spend to qualify for free shipping",
+    "type": "magento2-module",
+    "license": [
+        "GPL-3.0-or-later"
+    ],
+    "version": "0.0.1",
+    "require": {
+        "php": "~8.1.0||~8.2.0||~8.3.0",
+        "magento/framework": "103.0.*",
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "BeckyDoggett\\FreeShippingPromotion\\": ""
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "version": "0.0.1",
     "require": {
         "php": "~8.1.0||~8.2.0||~8.3.0",
-        "magento/framework": "103.0.*",
+        "magento/framework": "103.0.*"
     },
     "autoload": {
         "files": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="carriers">
+            <group id="freeshipping">
+                <field id="promote_in_cart" translate="label" type="select"
+                       sortOrder="200"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       canRestore="1">
+                    <label><![CDATA[Promote Free Shipping in Cart]]></label>
+                    <comment>
+                        <![CDATA[Show customers amount left to spend before they qualify for free delivery]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -11,7 +11,21 @@
                        canRestore="1">
                     <label><![CDATA[Promote Free Shipping in Cart]]></label>
                     <comment>
-                        <![CDATA[Show customers amount left to spend before they qualify for free delivery]]>
+                        <![CDATA[Show customers amount left to spend before they qualify for free delivery.]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+                <field id="promote_in_minicart" translate="label" type="select"
+                       sortOrder="210"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       canRestore="1">
+                    <label><![CDATA[Promote Free Shipping in Mini Cart]]></label>
+                    <comment>
+                        <![CDATA[Show customers amount left to spend before they qualify for free delivery.]]>
                     </comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,6 +5,7 @@
         <carriers>
             <freeshipping>
                 <promote_in_cart>0</promote_in_cart>
+                <promote_in_minicart>0</promote_in_minicart>
             </freeshipping>
         </carriers>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <carriers>
+            <freeshipping>
+                <promote_in_cart>0</promote_in_cart>
+            </freeshipping>
+        </carriers>
+    </default>
+</config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Customer\CustomerData\SectionPoolInterface">
+        <arguments>
+            <argument name="sectionSourceMap" xsi:type="array">
+                <item name="cart-totals" xsi:type="string">BeckyDoggett\FreeShippingPromotion\CustomerData\CartTotals</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+    <action name="checkout/cart/add">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/delete">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/updatePost">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/updateItemOptions">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/couponPost">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/estimatePost">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/cart/estimateUpdatePost">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/onepage/saveOrder">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/sidebar/removeItem">
+        <section name="cart-totals"/>
+    </action>
+    <action name="checkout/sidebar/updateItemQty">
+        <section name="cart-totals"/>
+    </action>
+    <action name="rest/*/V1/carts/*/payment-information">
+        <section name="cart-totals"/>
+    </action>
+    <action name="rest/*/V1/guest-carts/*/payment-information">
+        <section name="cart-totals"/>
+    </action>
+    <action name="rest/*/V1/guest-carts/*/selected-payment-method">
+        <section name="cart-totals"/>
+    </action>
+    <action name="rest/*/V1/carts/*/selected-payment-method">
+        <section name="cart-totals"/>
+    </action>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="BeckyDoggett_FreeShippingPromotion"/>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="BeckyDoggett_FreeShippingPromotion">
+        <sequence>
+            <module name="Magento_OfflineShipping"/>
+        </sequence>
+    </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="BeckyDoggett_FreeShippingPromotion">
         <sequence>
+            <module name="Magento_Checkout"/>
             <module name="Magento_OfflineShipping"/>
         </sequence>
     </module>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="BeckyDoggett_FreeShippingPromotion"/>
+</config>

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,9 @@
+<?php
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'BeckyDoggett_FreeShippingPromotion',
+    __DIR__
+);

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="checkout.cart.widget">
+            <block class="BeckyDoggett\FreeShippingPromotion\Block\Cart\ShippingPromotion"
+                   name="checkout.cart.shipping.promotion"
+                   ifconfig="carriers/freeshipping/promote_in_cart"
+                   template="BeckyDoggett_FreeShippingPromotion::cart/shipping/promotion.phtml"/>
+        </referenceContainer>
+
+    </body>
+</page>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -8,6 +8,5 @@
                    ifconfig="carriers/freeshipping/promote_in_cart"
                    template="BeckyDoggett_FreeShippingPromotion::cart/shipping/promotion.phtml"/>
         </referenceContainer>
-
     </body>
 </page>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -2,9 +2,10 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="checkout.cart.widget">
+        <referenceContainer name="cart.summary">
             <block class="BeckyDoggett\FreeShippingPromotion\Block\Cart\ShippingPromotion"
                    name="checkout.cart.shipping.promotion"
+                   after="checkout.cart.summary.title"
                    ifconfig="carriers/freeshipping/promote_in_cart"
                    template="BeckyDoggett_FreeShippingPromotion::cart/shipping/promotion.phtml"/>
         </referenceContainer>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="minicart.addons">
+            <block class="BeckyDoggett\FreeShippingPromotion\Block\Cart\ShippingPromotion"
+                   name="checkout.minicart.shipping.promotion"
+                   ifconfig="carriers/freeshipping/promote_in_minicart"
+                   template="BeckyDoggett_FreeShippingPromotion::cart/shipping/promotion.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/templates/cart/shipping/promotion.phtml
+++ b/view/frontend/templates/cart/shipping/promotion.phtml
@@ -6,7 +6,8 @@
  */
 ?>
 <?php if ($block->isFreeShippingActive() && $block->getFreeShippingMinimumOrderAmount()): ?>
-    <div data-block="free-shipping-promotion"
+    <div class="block shipping-promotion"
+         data-block="free-shipping-promotion"
          data-bind="scope: 'spend-x-get-free-shipping'"
     >
         <!-- ko template: getTemplate() --><!-- /ko -->

--- a/view/frontend/templates/cart/shipping/promotion.phtml
+++ b/view/frontend/templates/cart/shipping/promotion.phtml
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @var BeckyDoggett\FreeShippingPromotion\Block\Cart\ShippingPromotion $block
+ * @var Magento\Framework\Escaper $escaper
+ */
+?>
+<?php if ($block->isFreeShippingActive()): ?>
+    <?= $escaper->escapeHtml($block->getFreeShippingMinimumOrderAmount()); ?>
+<?php endif; ?>

--- a/view/frontend/templates/cart/shipping/promotion.phtml
+++ b/view/frontend/templates/cart/shipping/promotion.phtml
@@ -5,6 +5,25 @@
  * @var Magento\Framework\Escaper $escaper
  */
 ?>
-<?php if ($block->isFreeShippingActive()): ?>
-    <?= $escaper->escapeHtml($block->getFreeShippingMinimumOrderAmount()); ?>
+<?php if ($block->isFreeShippingActive() && $block->getFreeShippingMinimumOrderAmount()): ?>
+    <div data-block="free-shipping-promotion"
+         data-bind="scope: 'spend-x-get-free-shipping'"
+    >
+        <!-- ko template: getTemplate() --><!-- /ko -->
+    </div>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "Magento_Ui/js/core/app": {
+                    "components" : {
+                        "spend-x-get-free-shipping" : {
+                            "component" : "BeckyDoggett_FreeShippingPromotion/js/view/free-shipping-promotion",
+                            "minimumOrderAmount" : "<?= $escaper->escapeJs($block->getFreeShippingMinimumOrderAmountInStoreCurrency());?>",
+                            "priceLocaleFormat" : <?= /* @noEscape */ $block->getLocalePriceFormatJson() ?>
+                        }
+                    }
+                }
+            }
+        }
+    </script>
 <?php endif; ?>

--- a/view/frontend/templates/cart/shipping/promotion.phtml
+++ b/view/frontend/templates/cart/shipping/promotion.phtml
@@ -5,7 +5,10 @@
  * @var Magento\Framework\Escaper $escaper
  */
 ?>
-<?php if ($block->isFreeShippingActive() && $block->getFreeShippingMinimumOrderAmount()): ?>
+<?php if ($block->isFreeShippingActive() && $block->getFreeShippingMinimumOrderAmount()):
+    $minimumOrderAmount = $block->getFreeShippingMinimumOrderAmountInStoreCurrency();
+    $includingTax = $block->isAmountIncludingTax();
+    ?>
     <div class="block shipping-promotion"
          data-block="free-shipping-promotion"
          data-bind="scope: 'spend-x-get-free-shipping'"
@@ -19,7 +22,8 @@
                     "components" : {
                         "spend-x-get-free-shipping" : {
                             "component" : "BeckyDoggett_FreeShippingPromotion/js/view/free-shipping-promotion",
-                            "minimumOrderAmount" : "<?= $escaper->escapeJs($block->getFreeShippingMinimumOrderAmountInStoreCurrency());?>",
+                            "minimumOrderAmount" : "<?= $escaper->escapeJs($minimumOrderAmount);?>",
+                            "includingTax" : "<?= $escaper->escapeJs($includingTax); ?>",
                             "priceLocaleFormat" : <?= /* @noEscape */ $block->getLocalePriceFormatJson() ?>
                         }
                     }

--- a/view/frontend/web/css/source/_module.less
+++ b/view/frontend/web/css/source/_module.less
@@ -1,0 +1,62 @@
+//
+//  Variables
+//  _____________________________________________
+@progress__height: 10px;
+@progress__border-radius: 10px;
+
+//
+//  Common
+//  _____________________________________________
+
+& when (@media-common = true) {
+    .shipping-promotion {
+        .block-content {
+            background-color: @page__background-color;
+            border: @border-width__base solid @theme__color__primary;
+            font-size: @font-size__l;
+            font-weight: @font-weight__bold;
+            margin: @indent__s 0;
+            padding: @indent__s;
+            text-align: center;
+            &.complete {
+                border-color: @theme__color__secondary;
+            }
+            .small {
+                font-size: @font-size__base;
+            }
+        }
+    }
+    .progress-bar {
+        background-color: @secondary__color;
+        border: @border-width__base solid @theme__color__primary;
+        border-radius: @progress__border-radius;
+        margin-top: @indent__xs;
+        height: @progress__height;
+        position: relative;
+        .progress {
+            background-color: @theme__color__primary;
+            position: absolute;
+            height: @progress__height;
+        }
+        &.full {
+            background-color: @theme__color__secondary;
+            border-color: @theme__color__secondary;
+        }
+    }
+}
+
+//
+//  Mobile
+//  _____________________________________________
+
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__l) {
+
+}
+
+//
+//  Desktop
+//  _____________________________________________
+
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__l) {
+
+}

--- a/view/frontend/web/js/view/free-shipping-promotion.js
+++ b/view/frontend/web/js/view/free-shipping-promotion.js
@@ -1,0 +1,89 @@
+define([
+    'ko',
+    'uiComponent',
+    'Magento_Customer/js/customer-data',
+    'Magento_Catalog/js/price-utils',
+    'jquery',
+    'mage/mage'
+], function (
+    ko,
+    Component,
+    customerData,
+    priceUtils,
+    $,
+    mage
+) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            template: 'BeckyDoggett_FreeShippingPromotion/free-shipping-promotion',
+            minimumOrderAmount: 0,
+            priceLocaleFormat: {
+                decimalSymbol: '.',
+                groupLength: 3,
+                groupSymbol: ',',
+                integerRequired: false,
+                pattern: "£%s",
+                precision: 2,
+                requiredPrecision: 2
+            },
+            freeMinimumAmountMessage: 'Free shipping for orders over %1.',
+            spendMoreMessage: 'Spend another %1 for free shipping.'
+        },
+
+        eligible: ko.observable(false),
+
+        initialize: function() {
+            this._super();
+            this.cart = customerData.get('cart');
+        },
+
+        getCartItemsTotal: function() {
+            return customerData.get('cart')().summary_count;
+        },
+
+        getCartSubtotal: function() {
+            return customerData.get('cart')().subtotalAmount;
+        },
+
+        hasFreeShipping: function() {
+            //If cart subtotal is greater or equal to minimum order amount
+            console.log('totals', [this.getCartSubtotal(),this.minimumOrderAmount]);
+            if(parseFloat(this.getCartSubtotal()) >= parseFloat(this.minimumOrderAmount)) {
+                this.eligible(true);
+                console.log('yes');
+            }
+            else {
+                this.eligible(false);
+                console.log('no');
+            }
+            console.log('Free?', this.eligible);
+
+            return this.eligible;
+        },
+
+        formatMinimumOrderAmount: function() {
+            return priceUtils.formatPriceLocale(this.minimumOrderAmount, this.priceLocaleFormat);
+        },
+
+        getFreeShippingMessage: function() {
+            const minimumOrderFormatted = this.formatMinimumOrderAmount();
+            return $.mage.__(this.freeMinimumAmountMessage).replace('%1', minimumOrderFormatted);
+        },
+
+        spendXForFreeShipping: function() {
+            let spend = 0;
+            // Check if already eligible for free shipping already
+            if( !this.eligible() ){
+                spend = this.minimumOrderAmount - this.getCartSubtotal();
+            }
+            return priceUtils.formatPriceLocale(spend, this.priceLocaleFormat);
+        },
+
+        getSpendXForFreeShippingMessage: function() {
+            const spendXAmount = this.spendXForFreeShipping();
+            return $.mage.__(this.spendMoreMessage).replace('%1', spendXAmount);
+        }
+    })
+});

--- a/view/frontend/web/js/view/free-shipping-promotion.js
+++ b/view/frontend/web/js/view/free-shipping-promotion.js
@@ -39,39 +39,41 @@ define([
             this.cart = customerData.get('cart');
         },
 
+        // Get cart items count
         getCartItemsTotal: function() {
             return customerData.get('cart')().summary_count;
         },
 
+        // Get cart subtotal
         getCartSubtotal: function() {
             return customerData.get('cart')().subtotalAmount;
         },
 
+        // Check if current cart is eligible for Free Shipping
         hasFreeShipping: function() {
             //If cart subtotal is greater or equal to minimum order amount
-            console.log('totals', [this.getCartSubtotal(),this.minimumOrderAmount]);
             if(parseFloat(this.getCartSubtotal()) >= parseFloat(this.minimumOrderAmount)) {
                 this.eligible(true);
-                console.log('yes');
             }
             else {
                 this.eligible(false);
-                console.log('no');
             }
-            console.log('Free?', this.eligible);
 
             return this.eligible;
         },
 
+        // Format minimum order amount
         formatMinimumOrderAmount: function() {
             return priceUtils.formatPriceLocale(this.minimumOrderAmount, this.priceLocaleFormat);
         },
 
+        // Get free shipping avaialble when you spend x info message
         getFreeShippingMessage: function() {
             const minimumOrderFormatted = this.formatMinimumOrderAmount();
             return $.mage.__(this.freeMinimumAmountMessage).replace('%1', minimumOrderFormatted);
         },
 
+        // Calculate how much left to spend and format
         spendXForFreeShipping: function() {
             let spend = 0;
             // Check if already eligible for free shipping already
@@ -81,9 +83,19 @@ define([
             return priceUtils.formatPriceLocale(spend, this.priceLocaleFormat);
         },
 
+        // Get how much left to spend message
         getSpendXForFreeShippingMessage: function() {
             const spendXAmount = this.spendXForFreeShipping();
             return $.mage.__(this.spendMoreMessage).replace('%1', spendXAmount);
+        },
+
+        // Get amount spent as a percentage of the minimum order amount for a progress bar
+        getProgressPercent: function() {
+            let percent = 100;
+            if( !this.eligible() ){
+                percent = ((this.getCartSubtotal() * 100) / this.minimumOrderAmount);
+            }
+            return percent;
         }
     })
 });

--- a/view/frontend/web/js/view/free-shipping-promotion.js
+++ b/view/frontend/web/js/view/free-shipping-promotion.js
@@ -19,6 +19,7 @@ define([
         defaults: {
             template: 'BeckyDoggett_FreeShippingPromotion/free-shipping-promotion',
             minimumOrderAmount: 0,
+            includingTax: 0,
             priceLocaleFormat: {
                 decimalSymbol: '.',
                 groupLength: 3,
@@ -28,7 +29,7 @@ define([
                 precision: 2,
                 requiredPrecision: 2
             },
-            freeMinimumAmountMessage: 'Free shipping for orders over %1.',
+            freeMinimumAmountMessage: 'Free shipping for orders over %1 %2.',
             spendMoreMessage: 'Spend another %1 for free shipping.'
         },
 
@@ -36,7 +37,6 @@ define([
 
         initialize: function() {
             this._super();
-            this.cart = customerData.get('cart');
         },
 
         // Get cart items count
@@ -46,7 +46,12 @@ define([
 
         // Get cart subtotal
         getCartSubtotal: function() {
-            return customerData.get('cart')().subtotalAmount;
+            if (this.includingTax === '1') {
+                return customerData.get('cart-totals')().subtotalIncTax;
+            }
+            else {
+                return customerData.get('cart-totals')().subtotalExcTax;
+            }
         },
 
         // Check if current cart is eligible for Free Shipping
@@ -70,7 +75,10 @@ define([
         // Get free shipping avaialble when you spend x info message
         getFreeShippingMessage: function() {
             const minimumOrderFormatted = this.formatMinimumOrderAmount();
-            return $.mage.__(this.freeMinimumAmountMessage).replace('%1', minimumOrderFormatted);
+            const includingTaxNote = this.includingTax === '1' ? 'inc. tax' : 'exc. tax';
+            return $.mage.__(this.freeMinimumAmountMessage)
+                .replace('%1', minimumOrderFormatted)
+                .replace('%2', includingTaxNote);
         },
 
         // Calculate how much left to spend and format

--- a/view/frontend/web/template/free-shipping-promotion.html
+++ b/view/frontend/web/template/free-shipping-promotion.html
@@ -1,0 +1,14 @@
+<div data-bind="if: getCartItemsTotal() > 0">
+    <!-- ko if: hasFreeShipping() -->
+    <div>
+        <p data-bind="i18n: 'Your order is eligible for Free Shipping!'"></p>
+    </div>
+    <!-- /ko -->
+    <!-- ko ifnot: hasFreeShipping() -->
+    <div>
+        <p data-bind="i18n: 'Free Shipping'"></p>
+        <p data-bind="text: getFreeShippingMessage()"></p>
+        <p data-bind="text: getSpendXForFreeShippingMessage()"></p>
+    </div>
+    <!-- /ko -->
+</div>

--- a/view/frontend/web/template/free-shipping-promotion.html
+++ b/view/frontend/web/template/free-shipping-promotion.html
@@ -1,14 +1,20 @@
 <div data-bind="if: getCartItemsTotal() > 0">
     <!-- ko if: hasFreeShipping() -->
-    <div>
+    <div class="block-content complete">
         <p data-bind="i18n: 'Your order is eligible for Free Shipping!'"></p>
+        <div class="progress-bar full"></div>
     </div>
     <!-- /ko -->
     <!-- ko ifnot: hasFreeShipping() -->
-    <div>
-        <p data-bind="i18n: 'Free Shipping'"></p>
-        <p data-bind="text: getFreeShippingMessage()"></p>
-        <p data-bind="text: getSpendXForFreeShippingMessage()"></p>
+    <div class="block-content">
+        <p>
+            <span data-bind="text: getFreeShippingMessage()"></span>
+            <br>
+            <span class="small" data-bind="text: getSpendXForFreeShippingMessage()"></span>
+        </p>
+        <div class="progress-bar">
+            <div class="progress" data-bind="style: { width: getProgressPercent() + '%' }"></div>
+        </div>
     </div>
     <!-- /ko -->
 </div>


### PR DESCRIPTION
### Added
- Promotional block for default Free Shipping method
- When enabled display how much a customer has left to spend before they qualify for free shipping
- Check if amount includes tax, promotional output is updated depending on setting
- Ability to enable promotion in the cart
- Ability to enable promotion in the mini-cart